### PR TITLE
chore: Loosened the azuyalabs/yasumi dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.0",
-        "azuyalabs/yasumi": "2.4.0"
+        "azuyalabs/yasumi": "^2.4"
     },
     "require-dev": {
         "pestphp/pest": "^1.21",


### PR DESCRIPTION
Usually on packages, dependencies should not be pinned to a specific version as it would block dependency bumps on applications.