### PR TITLE
test: fix Easter Monday test

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This package is for determining a UK employee tax allowance for a specific date range. 
 
-You may get weekly or monthly number of allowance, as well as weekly or monthly period end dates for the provided date range.
+You may get the weekly or monthly tax allowance, as well as weekly or monthly period end dates for the provided date range.
 
 ## Installation
 
@@ -17,7 +17,7 @@ composer require worksome/uk-tax-allowance
 
 ## Usages
 
-### UkTaxAllowanceCalculator
+### `UkTaxAllowanceCalculator`
 
 ```php
 /**
@@ -30,23 +30,24 @@ composer require worksome/uk-tax-allowance
 #### Weekly allowance
 
 ```php
-// Get weekly allowance count for a specific date range 
+// Get the weekly allowance count for a specific date range 
 $weeklyAllowanceCount = $ukTaxAllowanceCalculator->weekly($dateStart, $dateEnd);
 
-// Get weekly allowance end dates for a specific date range 
+// Get the weekly allowance end dates for a specific date range 
 $weeklyAllowanceEndDates = $ukTaxAllowanceCalculator->weeklyEndDatesBetween($dateStart, $dateEnd);
 ```
 
 #### Monthly allowance
+
 ```php
-// Get monthly allowance end dates for a specific date range 
+// Get the monthly allowance end dates for a specific date range 
 $monthlyAllowanceEndDates = $ukTaxAllowanceCalculator->monthlyEndDatesBetween($dateStart, $dateEnd);
-// Get monthly allowance count for a specific date range 
+// Get the monthly allowance count for a specific date range 
 $monthlyAllowanceCount = $ukTaxAllowanceCalculator->monthly($dateStart, $dateEnd);
 ```
 
 ### Calendar
 
-You may use our YasumiUkCalendar which relies on the azuyalabs/yasumi package. For Laravel users, `UkTaxAllowanceServiceProvider` will register it by default.
+You may use our `YasumiUkCalendar` which relies on the [`azuyalabs/yasumi`](https://github.com/azuyalabs/yasumi) package. For Laravel users, `UkTaxAllowanceServiceProvider` will register it by default.
 
 Or create your own and have it implement `Worksome\UkTaxAllowance\Contracts\UkCalendar`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Worksome Uk Allowance library
 
-[![Tests](https://github.com/worksome/uk-tax-allowance/actions/workflows/main.yml/badge.svg)](https://github.com/worksome/uk-tax-allowance/actions/workflows/main.yml)
-[![Code Analysis](https://github.com/worksome/uk-tax-allowance/actions/workflows/code-analysis.yml/badge.svg)](https://github.com/worksome/uk-tax-allowance/actions/workflows/code-analysis.yml)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/worksome/uk-tax-allowance.svg?style=flat-square&label=Packagist)](https://packagist.org/packages/worksome/uk-tax-allowance)
+[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/worksome/uk-tax-allowance/tests.yml?branch=main&style=flat-square&label=Tests)](https://github.com/worksome/uk-tax-allowance/actions?query=workflow%3ATests+branch%3Amain)
+[![GitHub Static Analysis Action Status](https://img.shields.io/github/actions/workflow/status/worksome/uk-tax-allowance/static.yml?branch=main&style=flat-square&label=Static%20Analysis)](https://github.com/worksome/uk-tax-allowance/actions?query=workflow%3A"Static%20Analysis"+branch%3Amain)
+[![Total Downloads](https://img.shields.io/packagist/dt/worksome/uk-tax-allowance.svg?style=flat-square&label=Downloads)](https://packagist.org/packages/worksome/uk-tax-allowance)
 
 This package is for determining a UK employee tax allowance for a specific date range. 
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
-        "azuyalabs/yasumi": "^2.5"
+        "azuyalabs/yasumi": "^2.10"
     },
     "require-dev": {
         "larastan/larastan": "^3.1",

--- a/src/Calendars/YasumiUkCalendar.php
+++ b/src/Calendars/YasumiUkCalendar.php
@@ -10,22 +10,20 @@ use Yasumi\Yasumi;
 
 class YasumiUkCalendar implements UkCalendar
 {
-    protected const FUTURE = 1;
+    protected const int FUTURE = 1;
 
-    protected const PAST = -1;
+    protected const int PAST = -1;
 
     /** {@inheritdoc} */
     public function isWeekendDay(Carbon $date): bool
     {
-        return $this->getCalendar($date)
-            ->isWeekendDay($date);
+        return $this->getCalendar($date)->isWeekendDay($date);
     }
 
     /** {@inheritdoc} */
     public function isHoliday(Carbon $date): bool
     {
-        return $this->getCalendar($date)
-            ->isHoliday($date);
+        return $this->getCalendar($date)->isHoliday($date);
     }
 
     /** {@inheritdoc} */

--- a/tests/Calendars/YasumiUkCalendarTest.php
+++ b/tests/Calendars/YasumiUkCalendarTest.php
@@ -25,6 +25,6 @@ it('returns correct closest future working day', function ($day, $expectedCloses
 
     expect($closestFutureWorkingDay->toDateString())->toEqual($expectedClosestFutureWorkingDay);
 })->with([
-    ['2021-04-02', '2021-04-06'],
+    ['2021-04-02', '2021-04-05'],
     ['2021-05-29', '2021-06-01'],
 ]);


### PR DESCRIPTION
This updates the test for Easter Monday, as it's no longer a UK-wide holiday.